### PR TITLE
Add missing "include string" required for compilation

### DIFF
--- a/include/GRootWriter.h
+++ b/include/GRootWriter.h
@@ -19,7 +19,11 @@ class TFile;
 #include "TTree.h"
 #include "TFile.h"
 
+#include <string>
+
 #include "Math/Vector3Dfwd.h"
+
+using namespace std;
 
 class GRootWriter
 {


### PR DESCRIPTION
Missing include in `include/GRootWriter.h` which prevents it from compiling (at least on centos7).